### PR TITLE
Adjusted Canvas Size to 960x540 and Improved Background Logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,6 @@
   </head>
   <body onload="init()">
     <h1>Fantasy Platformer</h1>
-    <canvas id="canvas" width="1200px" height="680" ></canvas>
+    <canvas id="canvas" width="960px" height="540px"></canvas>
   </body>
 </html>

--- a/levels/level1.js
+++ b/levels/level1.js
@@ -1,35 +1,25 @@
+function createBackgroundLayer(imagePath, count, width) {
+  const layer = [];
+  for (let i = 0; i < count; i++) {
+    layer.push(new BackgroundObjeckt(imagePath, i * (width - 1), 0));
+  }
+  return layer;
+}
+
+const CANVAS_WIDTH = 960;
+const backgrounds = [
+  ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/sky.png', 5, CANVAS_WIDTH),
+  ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds1.png', 5, CANVAS_WIDTH),
+  ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds2.png', 5, CANVAS_WIDTH),
+  ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks.png', 5, CANVAS_WIDTH),
+  ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks2.png', 5, CANVAS_WIDTH),
+  ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks3.png', 5, CANVAS_WIDTH),
+];
+
 const level1 = new Level(
   [new EnemiesAnt(), new Endboss()],
   [new Cloud()],
-  [
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/sky.png', 0, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds1.png', 0, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds2.png', 0, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks.png', 0, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks2.png', 0, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks3.png', 0, 0),
-
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/sky.png', 599 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds1.png', 599 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds2.png', 599 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks.png', 599 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks2.png', 599 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks3.png', 599 *2, 0),
-
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/sky.png', 1198 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds1.png', 1198 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds2.png', 1198 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks.png', 1198 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks2.png', 1198 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks3.png', 1198 *2, 0),
-
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/sky.png', 1777 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds1.png', 1777 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds2.png', 1777 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks.png', 1777 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks2.png', 1777 *2, 0),
-    new BackgroundObjeckt('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks3.png', 1777 *2, 0),
-  ],
+  backgrounds,
   [new Coins(), new Coins(), new Coins(), new Coins(), new Coins(), new Coins()],
   [new Bottle(), new Bottle(), new Bottle()]
 );

--- a/models/background-object.class.js
+++ b/models/background-object.class.js
@@ -1,11 +1,19 @@
 class BackgroundObjeckt extends MoveleObjekt {
-  width = 1200;
-  height = 700;
+  width = 960;
+  height = 540;
   x = 0;
 
   constructor(imgePath, x, y) {
     super().loadImage(imgePath);
     this.x = x;
     this.y = y; 
+  }
+
+  draw(ctx) {
+    try {
+      ctx.drawImage(this.img, Math.round(this.x), this.y, this.width, this.height);
+    } catch (e) {
+      console.warn('Dieses Background-Objekt konnte nicht gezeichnet werden:', this);
+    }
   }
 }

--- a/models/character.class.js
+++ b/models/character.class.js
@@ -1,8 +1,8 @@
 class Character extends MoveleObjekt {
   y = 420;
   x = 0;
-  height = 300;
-  width = 300;
+  height = 200;
+  width = 200;
 
   speed = 1.5;
 
@@ -29,9 +29,9 @@ class Character extends MoveleObjekt {
   constructor() {
     super().loadImage('assets/assassin-mage-viking-free-pixel-art-game-heroes/PNG/Rogue/rogue.png');
     this.offset = {
-      top: 140,
-      left: 50,
-      right: 135,
+      top: 90,
+      left: 35,
+      right: 90,
       bottom: 0,
     };
     this.loadImages(this.IMAGES_WALKING);

--- a/models/cloud.class.js
+++ b/models/cloud.class.js
@@ -1,7 +1,7 @@
 class Cloud extends MoveleObjekt {
   y = 550;
-  width = 1200;
-  height = 700;
+  width = 960;
+  height = 540;
 
   constructor() {
     super().loadImage('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds4.png');

--- a/models/endboss.class.js
+++ b/models/endboss.class.js
@@ -1,6 +1,6 @@
 class Endboss extends MoveleObjekt {
-  height = 700;
-  width = 650;
+  height = 400;
+  width = 400;
   y = 116;
   x = 0;
 
@@ -16,10 +16,10 @@ class Endboss extends MoveleObjekt {
   constructor() {
     super().loadImage(this.IMAGES_WALKING[0]);
     this.offset = {
-      top: 230,
-      left: 250,
-      right: 125 ,
-      bottom: 130, 
+      top: 140,
+      left: 150,
+      right: 75,
+      bottom: 80, 
     };
     this.loadImages(this.IMAGES_WALKING);
     this.x = 2700;

--- a/models/enemies.class.js
+++ b/models/enemies.class.js
@@ -1,8 +1,8 @@
 class EnemiesAnt extends MoveleObjekt {
   y = 350;
   x = 40;
-  height = 500;
-  width = 500;
+  height = 300;
+  width = 300;
 
   IMAGES_WALKING = [
     'assets/2d-pixel-art-evil-monster-sprites/PNG/Big_knight/big_knight04_walk1.png',
@@ -20,10 +20,10 @@ class EnemiesAnt extends MoveleObjekt {
     this.loadImages(this.IMAGES_WALKING);
     this.animate();
     this.offset = {
-      top: 155,
-      left: 190,
-      right: 170,
-      bottom: 170,
+      top: 95,
+      left: 115,
+      right: 105,
+      bottom: 105,
     };
   }
 

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ h1 {
   letter-spacing: 3px;
 }
 
-@media only screen and (max-height: 1200px) {
+/* @media only screen and (max-height: 1200px) {
   canvas {
     width: 100vh;
   }
@@ -45,4 +45,4 @@ h1 {
   canvas {
     width: 100vh;
   }
-}
+} */


### PR DESCRIPTION
- Reduced Canvas size in index.html to 960x540
- Migrated all Background objects and Clouds to the new size
- Introduced and optimized createBackgroundLayer function for automatic and seamless background placement (including 1px overlap to prevent lines)
- Increased number of background tiles to 5
- Adjusted draw method for Background objects (x-position is rounded)
- Refactored code for better maintainability and flexibility