### PR TITLE
Fix statusbar collision system

### DIFF
--- a/js/characters/character.class.js
+++ b/js/characters/character.class.js
@@ -19,6 +19,7 @@ class Character extends MovableObject {
     this.applyGravity();
 
     this.lastMoveTime = new Date().getTime();
+    this.hit = false; // Hit-Status für Kollisionsschutz
   }
 
   isDeath() {

--- a/js/core/collision-manager.class.js
+++ b/js/core/collision-manager.class.js
@@ -40,15 +40,29 @@ class CollisionManager {
     }
   }
 
+  // handleEnemyCollision(enemy) {
+  //   setTimeout(() => {
+  //     this.world.character.energy -= 5;
+  //     if (this.world.character.energy <= 0) {
+  //       this.world.character.energy = 0;
+  //     }
+  //     this.world.statusBar.setPercentage(this.world.character.energy);
+  //     console.log('Kollision mit Gegner, Energie:', this.world.character.energy);
+  //   }, 2.0 * 2000);
+  // }
   handleEnemyCollision(enemy) {
-    setTimeout(() => {
-      this.world.character.energy -= 5;
+    if (!this.world.character.hit && !this.world.character.isDeath()) {
+      this.world.character.energy -= 2; // Weniger Schaden
       if (this.world.character.energy <= 0) {
         this.world.character.energy = 0;
+        this.world.character.hit = true;
+        setTimeout(() => {
+          this.world.character.hit = false;
+        }, 1500); // Längere Invulnerabilität
       }
       this.world.statusBar.setPercentage(this.world.character.energy);
       console.log('Kollision mit Gegner, Energie:', this.world.character.energy);
-    }, 2.0 * 2000);
+    }
   }
 
   handleCoinCollection(coin) {
@@ -64,7 +78,17 @@ class CollisionManager {
   }
 
   handleEndbossCollision(endboss) {
-    this.world.character.energy -= 10;
-    console.log('Kollision mit Endboss, Energie:', this.world.character.energy);
+    if (!this.world.character.hit && !this.world.character.isDeath()) {
+      this.world.character.energy -= 5; // Weniger Schaden vom Endboss
+      if (this.world.character.energy <= 0) {
+        this.world.character.energy = 0;
+        this.world.character.hit = true;
+        setTimeout(() => {
+          this.world.character.hit = false;
+        }, 1500);
+      }
+      this.world.statusBar.setPercentage(this.world.character.energy);
+      console.log('Kollision mit Endboss, Energie:', this.world.character.energy);
+    }
   }
 }

--- a/js/core/statusbar.class.js
+++ b/js/core/statusbar.class.js
@@ -5,8 +5,8 @@ class Statusbar extends DrawableObject {
 
   percentage = 100;
 
-  //CHARACTER_STATUSBAR = ['assets/fantasy-platformer-game-ui/PNG/16Inner_Interface/hp_bar_full.png'];
-  ENERGY = ['assets/fantasy-platformer-game-ui/PNG/16Inner_Interface/hp_full.png'];
+  CHARACTER_STATUSBAR = ['assets/fantasy-platformer-game-ui/PNG/16Inner_Interface/hp_bar_full.png'];
+  //ENERGY = ['assets/fantasy-platformer-game-ui/PNG/16Inner_Interface/hp_full.png'];
   CHARACTER_STATUSBAR = [
     'assets/fantasy-platformer-game-ui/PNG/16Inner_Interface/hp_full6/00_hp_full6.png',
     'assets/fantasy-platformer-game-ui/PNG/16Inner_Interface/hp_full6/01_hp_full6.png',
@@ -24,15 +24,23 @@ class Statusbar extends DrawableObject {
     this.x = 10;
     this.width = 200;
     this.height = 30;
+    this.visible = true;
     this.setPercentage(100);
 
     console.log('Statusbar liegt auf der y-Achse (y = ' + this.y + ')');
   }
 
   setPercentage(percentage) {
-    this.percentage = percentage;
-    let path = this.CHARACTER_STATUSBAR[this.resolveImageIndex()];
-    this.img = this.imageCache[path];
+    this.percentage = Math.round(percentage);
+    if (this.percentage <= 0) {
+      this.percentage = 0;
+      // Statusbar ausblenden wenn Energie 0
+      this.visible = false;
+    } else {
+      this.visible = true;
+      let path = this.CHARACTER_STATUSBAR[this.resolveImageIndex()];
+      this.img = this.imageCache[path];
+    }
   }
 
   // setPercentage(percentage) {
@@ -40,17 +48,17 @@ class Statusbar extends DrawableObject {
   // }
 
   resolveImageIndex() {
-    if (this.percentage == 100) {
+    if (this.percentage > 83.33) {
       return 5;
-    } else if (this.percentage > 80) {
+    } else if (this.percentage > 66.66) {
       return 4;
-    } else if (this.percentage > 60) {
+    } else if (this.percentage > 50) {
       return 3;
-    } else if (this.percentage > 40) {
+    } else if (this.percentage > 33.33) {
       return 2;
-    } else if (this.percentage > 20) {
+    } else if (this.percentage > 16.66) {
       return 1;
-    } else if (this.percentage > 0) {
+    } else {
       return 0;
     }
   }

--- a/js/core/world.class.js
+++ b/js/core/world.class.js
@@ -9,7 +9,7 @@ class World {
   coins;
   bottles;
   collisionManager;
-  //statusBar = new Statusbar();
+  statusBar = new Statusbar();
 
   constructor(canvas, keyboard) {
     this.ctx = canvas.getContext('2d');
@@ -20,6 +20,8 @@ class World {
     this.character.animate();
     this.draw();
     this.checkCollisions();
+    // Statusbar mit initialer Energie synchronisieren
+    this.statusBar.setPercentage(this.character.energy);
   }
 
   setWorld() {
@@ -29,7 +31,6 @@ class World {
   checkCollisions() {
     setInterval(() => {
       this.collisionManager.checkAllCollisions();
-
     }, 1000 / 60);
   }
 
@@ -37,16 +38,19 @@ class World {
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
     this.addObjectsToMap(this.level.backgroundObjectRocks);
+
+    // Statusbar nur zeichnen, wenn der Spieler noch lebt
+    if (!this.character.isDeath()) {
+      this.ctx.translate(-this.camera_x, 0); // back
+      this.addToMap(this.statusBar);
+      this.ctx.translate(this.camera_x, 0); // Forwards
+    }
+
     this.addObjectsToMap(this.level.clouds);
     this.addToMap(this.character);
     this.addObjectsToMap(this.level.enemiesAnt);
     this.addObjectsToMap(this.level.coins);
     this.addObjectsToMap(this.level.bottles);
-
-    // Statusbar ohne Kamera-Bewegung zeichnen
-    this.ctx.save();
-    // this.addToMap(this.statusBar);
-    this.ctx.restore();
 
     self = this;
     requestAnimationFrame(function () {
@@ -55,8 +59,13 @@ class World {
   }
 
   addToMap(mo) {
+    // Nicht zeichnen wenn Objekt nicht sichtbar ist
+    if (mo.visible === false) {
+      return;
+    }
+
     this.ctx.save();
-    
+
     // Parallax-Effekt für BackgroundObjects
     if (mo instanceof BackgroundObject) {
       this.ctx.translate(this.camera_x * mo.parallax, 0);
@@ -64,7 +73,7 @@ class World {
       // Normale Kamera-Bewegung für andere Objekte
       this.ctx.translate(this.camera_x, 0);
     }
-    
+
     if (mo.otherDirection) {
       this.ctx.translate(mo.x + mo.width, mo.y);
       this.ctx.scale(-1, 1);

--- a/js/levels/level1.js
+++ b/js/levels/level1.js
@@ -12,7 +12,7 @@ function createBackgroundLayer(imagePath, count, width, yOffset = 0, parallax = 
 }
 
 const backgroundObjects = [
-  ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/sky.png', 5, CANVAS_WIDTH, 0, 0.2),
+  ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/sky.png', 5, CANVAS_WIDTH, 0, 0),
   ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds1.png', 5, CANVAS_WIDTH, 50, 0.4),
   ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/clouds2.png', 5, CANVAS_WIDTH, 75, 0.6),
   ...createBackgroundLayer('/assets/mountain-platformer-pixel-art-tileset/PNG/Background/bright/rocks.png', 5, CANVAS_WIDTH, 100, 0.8),


### PR DESCRIPTION
- Reduce damage from 5 to 2 points per enemy collision
- Reduce endboss damage from 10 to 5 points
- Increase invulnerability time from 1000ms to 1500ms
- Add death check to prevent collisions after death
- Hide statusbar when player dies (energy = 0)
- Add visible property to statusbar class
- Fix world.character.hit reference bug
- Initialize statusbar with character energy
- Add hit property to character constructor